### PR TITLE
Fix bugs and improve POS system efficiency

### DIFF
--- a/Boss/CashUp.vb
+++ b/Boss/CashUp.vb
@@ -1,4 +1,4 @@
-﻿Imports System.Data.OleDb
+Imports System.Data.OleDb
 Public Class CashUp
 
     Private Sub btnBack_Click(sender As Object, e As EventArgs) Handles btnBack.Click
@@ -80,14 +80,14 @@ Public Class CashUp
 
         End Try
         Try
-            Dim sqlconn As New OleDb.OleDbConnection
-            Dim connstring, command As String
-            connstring = My.Settings.BossConnectionString
-            sqlconn.ConnectionString = connstring
-            sqlconn.Open()
-            command = "DELETE * FROM DTotals WHERE TDate = '" & Today & "'"
-            Dim sql As OleDbCommand = New OleDbCommand(command, sqlconn)
-            sql.ExecuteNonQuery()
+            Using sqlconn As New OleDb.OleDbConnection(My.Settings.BossConnectionString)
+                sqlconn.Open()
+                Dim command As String = "DELETE * FROM DTotals WHERE TDate = @Date"
+                Using sql As New OleDbCommand(command, sqlconn)
+                    sql.Parameters.AddWithValue("@Date", Today.Date)
+                    sql.ExecuteNonQuery()
+                End Using
+            End Using
             MsgBox("Daily Total Reset")
             Me.Controls.Clear()
             InitializeComponent()

--- a/Boss/EOD.vb
+++ b/Boss/EOD.vb
@@ -1,4 +1,4 @@
-﻿Public Class EOD
+Public Class EOD
 
     Private Sub btnBack_Click(sender As Object, e As EventArgs) Handles btnBack.Click
         Me.Hide()
@@ -14,10 +14,14 @@
     End Sub
 
     Private Sub EOD_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        If Login.txtPassword.Text = "hebi0800" Then
-            rtfReceipt.Enabled = True
-        Else
-            rtfReceipt.Enabled = False
-        End If
+        rtfReceipt.Enabled = (Login.txtPassword.Text = "hebi0800")
+
+        ' Auto-generate today's EOD report
+        Try
+            Dim reportText As String = BusinessLogicLayer.GenerateEODReport(DateTime.Today)
+            rtfReceipt.Text = reportText
+        Catch ex As Exception
+            rtfReceipt.Text = "Failed to generate EOD report: " & ex.Message
+        End Try
     End Sub
 End Class


### PR DESCRIPTION
Implement EOD reporting, fix daily totals, and improve sales entry logic for Boss Cafe POS.

The existing system suffered from incorrect daily total calculations, unreliable item removal, and lacked a proper end-of-day report. This PR introduces robust data access methods, corrects currency conversions, ensures proper database resource management, and provides a comprehensive, automatically generated EOD report for supervisors.

---
<a href="https://cursor.com/background-agent?bcId=bc-6125d0a2-fa6a-4171-af02-925e4bfff624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6125d0a2-fa6a-4171-af02-925e4bfff624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce text EOD reporting with sales/waiter summaries, improve data access (upsert totals, decimal handling, resource safety), and fix sales entry logic (receipt count, item removal, product lookup).
> 
> - **Business Logic (`Boss/BusinessLogicLayer.vb`)**:
>   - **EOD**: Add `GenerateEODReport(targetDate)` producing a text report; expose `GetSalesSummary(...)`, `GetWaiterTotals(...)`, and `GetProductByCode(...)`.
> - **Data Access (`Boss/DataAccessLayer.vb`)**:
>   - Add `GetProductByCode`, `GetSalesSummary`, `GetWaiterTotals` and DTOs `SalesSummaryData`, `WaiterTotalData`.
>   - Use decimals for totals (`ZTotal`, `UTotal`); `ExecuteQuery` returns reader with `CloseConnection`.
>   - `UpdateDailyTotals` now upserts when no row exists.
> - **UI/Forms**:
>   - `Boss/EOD.vb`: Auto-generate today’s report on load; simplify `rtfReceipt` enable check.
>   - `Boss/Entries.vb`: Stop `Timer3`; compute receipt count via increment; use `GetProductByCode` in `RecalculateCurrentSale`; implement robust `remove_Click` to remove last item and recompute totals; stop `Timer3` in tick.
>   - `Boss/CashUp.vb`: Parameterized daily totals reset with `Using`; minor cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce33ca1299bf025d21839fb94ce65607e7f0996. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->